### PR TITLE
Cart retains items after user login

### DIFF
--- a/spec/features/unauth_users/user_manages_cart_spec.rb
+++ b/spec/features/unauth_users/user_manages_cart_spec.rb
@@ -34,11 +34,27 @@ RSpec.describe "user managing cart", type: :feature do
     expect(page).to have_content("Quantity: 2")
   end
 
+  it "can login and the cart should not change" do
+    create_item_and_add_to_cart
+    visit cart_path
+    expect(page).to have_content("Quantity: 1")
+    visit account_path
+    user_log_in
+    visit cart_path
+    expect(page).to have_content("Quantity: 1")
+  end
+
   private
 
   def create_item_and_add_to_cart
     create(:item)
-    visit "/menu"
+    visit menu_path
     click_link_or_button "Add to Cart"
+  end
+
+  def user_log_in
+    fill_in "session[email]", with: "richard@example.com"
+    fill_in "session[password]", with: "password"
+    click_link_or_button "Login"
   end
 end


### PR DESCRIPTION
This really wasn't much of a change at all. As it turns out, the cart does not change regardless of a session login by default, so all I did was put a test on it.

Closes #28 